### PR TITLE
Support ReservedIP object

### DIFF
--- a/all_json.go
+++ b/all_json.go
@@ -42,4 +42,11 @@ type Metadata struct {
 			Active    bool   `json:"active,omitempty"`
 		} `json:"ipv4,omitempty"`
 	} `json:"floating_ip",omitempty"`
+
+	ReservedIP struct {
+		IPv4 struct {
+			IPAddress string `json:"ip_address,omitempty"`
+			Active    bool   `json:"active,omitempty"`
+		} `json:"ipv4,omitempty"`
+	} `json:"reserved_ip",omitempty"`
 }

--- a/client.go
+++ b/client.go
@@ -213,6 +213,20 @@ func (c *Client) FloatingIPv4Active() (bool, error) {
 	return active, err
 }
 
+// ReservedIPv4Active returns true if an IPv4 Reserved IP
+// Address is assigned to the Droplet.
+func (c *Client) ReservedIPv4Active() (bool, error) {
+	var active bool
+	err := c.doGet("reserved_ip/ipv4/active", func(r io.Reader) error {
+		activeraw, err := ioutil.ReadAll(r)
+		if string(activeraw) == "true" {
+			active = true
+		}
+		return err
+	})
+	return active, err
+}
+
 func (c *Client) doGet(resource string, decoder func(r io.Reader) error) error {
 	return c.doGetURL(c.resolve(defaultPath, resource), decoder)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -200,6 +200,43 @@ func TestFloatingIPv4Active(t *testing.T) {
 	}
 }
 
+func TestReservedIPv4Active(t *testing.T) {
+	tests := []struct {
+		resp string
+		want bool
+	}{
+		{
+			resp: "true",
+			want: true,
+		},
+		{
+			resp: "false",
+			want: false,
+		},
+		{
+			resp: "",
+			want: false,
+		},
+		{
+			resp: "something stange",
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		withServer(t, "/metadata/v1/reserved_ip/ipv4/active", test.resp, func(client *Client) {
+			got, err := client.ReservedIPv4Active()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(test.want, got) {
+				t.Errorf("want=%#v", test.want)
+				t.Errorf(" got=%#v", got)
+			}
+		})
+	}
+}
+
 func TestMetadata(t *testing.T) {
 	resp := `{
   "droplet_id": 7473395,
@@ -241,6 +278,12 @@ func TestMetadata(t *testing.T) {
     ]
   },
   "floating_ip": {
+    "ipv4": {
+      "ip_address": "192.168.0.100",
+      "active": true
+    }
+  },
+  "reserved_ip": {
     "ipv4": {
       "ip_address": "192.168.0.100",
       "active": true


### PR DESCRIPTION
This change introduces `ReservedIP` object type and complementary retrieve API. `ReservedIP` is renamed `FloatingIP` object, the latter will eventually be deprecated. This is not intended as breaking-change, thus `FloatingIP` will still be supported for now.